### PR TITLE
add: Googleログインの実装

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "~/styles/globals.css";
 
 import { GeistSans } from "geist/font/sans";
 import { type Metadata } from "next";
+import { SessionProvider } from "next-auth/react";
 
 export const metadata: Metadata = {
   title: "Create T3 App",
@@ -14,7 +15,11 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" className={`${GeistSans.variable}`}>
-      <body>{children}</body>
+      <body>
+        <SessionProvider>
+          {children}
+        </SessionProvider>
+      </body>
     </html>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,19 +1,20 @@
-import Image from "next/image";
-import Link from "next/link";
+"use client"
+import { signIn } from "next-auth/react";
 import { Button } from "~/components/ui/button";
 
 export default function Login() {
   return (
     <div className="flex h-screen flex-col items-center justify-center text-center">
       {/* 新規登録 */}
-      <Button size="xl" className="mb-10">
-        <Link href="/question">新規登録</Link>
+      <Button onClick={() => signIn("google", { callbackUrl: "/question" })} size="xl" className="mb-10">
+        新規登録
       </Button>
 
       {/* ログイン */}
-      <Button size="xl">
-        <Link href="/home">ログイン</Link>
+      <Button onClick={() => signIn("google", { callbackUrl: "/home" })} size="xl">
+        ログイン
       </Button>
     </div>
   );
 }
+

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -32,7 +32,10 @@ declare module "next-auth" {
  */
 export const authConfig = {
   providers: [
-    GoogleProvider,
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
     /**
      * ...add more providers here.
      *


### PR DESCRIPTION
## 概要

Googleログインを実装しました。localhost:3000/login「新規登録」「ログイン」を押すとGoogle認証画面に遷移し、認証後はそれぞれアンケート画面とホーム画面に遷移するよう設定しています。

## 変更点

- server/auth/config.tsに追加情報を記載
- app/layout.tsxにSessionProviderをインポート
- app/login/page.tsxのボタン周りを修正

## 確認方法

.envにGOOGLEのIDとSECRETを記載するようにしてください（IDとSECRETが分からなければ教えます）

## 影響範囲

ログイン画面

## テスト

- [x] ボタン押したらGoogle認証画面に遷移する
- [x] Google認証後の画面遷移が問題なく行える
